### PR TITLE
Refresh profile README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,55 @@
-<h2> <img src="https://emojis.slackmojis.com/emojis/images/1588315024/8823/hyperkitty.gif?1588315024" width="30" /> Hi, welcome! </h2>
+<div align="center">
 
-I am Adarsh Singh. I consider myself as a smart worker and determined team player. I am an experienced developer skilled in C++, Java, Kotlin, SQL and Android Development.
+<img src="https://readme-typing-svg.demolab.com?font=Fira+Code&size=28&duration=3500&pause=800&color=58A6FF&center=true&vCenter=true&width=680&lines=Hi%2C+I'm+Adarsh+Singh;Backend+%2F+Distributed+Systems+Engineer;Kubernetes+%C2%B7+Networking+%C2%B7+Data+Infrastructure" alt="Intro" />
 
+</div>
 
-&nbsp;
-### ⚙️ &nbsp;GitHub Analytics 
-<a href="https://github.com/2001adarsh?tab=repositories">
- <img align="center" src="https://github-readme-stats.vercel.app/api?username=2001adarsh&theme=react&show_icons=true" alt="Adarsh's github stats"/>
-</a>
+---
 
-<a href="https://github.com/2001adarsh?tab=repositories">
-  <img align="center" src="https://github-readme-stats.vercel.app/api/top-langs/?username=2001adarsh&theme=react&layout=compact&show_icons=true" />
-</a>
+### About
 
-*NOTE: Top languages does not indicate my skill level or something like that, it's a github metric of which languages i have the most code on github, it's a new feature of [github-readme-stats](https://github.com/anuraghazra/github-readme-stats)*
+Backend / Distributed Systems engineer at **Pure Storage**, working on **PX-Backup** — Kubernetes-native backup for stateful workloads.
 
---------
+Previously **Sophos** (ZTNA) and **F5** (5G SCP, ZTNA). Distributed systems and the networking & data infrastructure underneath them have been the through-line across roles.
 
-### &nbsp;<img src="https://emojis.slackmojis.com/emojis/images/1569381018/6481/heart-8bit-1.gif?1569381018" width="28" /> Remember</h3>
+Outside of work I tinker. Recent interests: Go, Kubernetes internals, MCP servers (`jenkins-mcp-go`), and observability tooling. **The repos here are mostly that — things I built to learn, not what I ship at work.**
 
-```
-  _ __   _____   _____ _ __    ___  __ _ _   _    _ __   _____   _____ _ __
- | '_ \ / _ \ \ / / _ \ '__|  / __|/ _` | | | |  | '_ \ / _ \ \ / / _ \ '__|
- | | | |  __/\ V /  __/ |     \__ \ (_| | |_| |  | | | |  __/\ V /  __/ |
- |_| |_|\___| \_/ \___|_|     |___/\__,_|\__, |  |_| |_|\___| \_/ \___|_|
-                                         |___/
-```
+---
+
+### Tech Stack
+
+**Languages**
+
+![Go](https://img.shields.io/badge/Go-00ADD8?style=for-the-badge&logo=go&logoColor=white)
+![Java](https://img.shields.io/badge/Java-ED8B00?style=for-the-badge&logo=openjdk&logoColor=white)
+![Kotlin](https://img.shields.io/badge/Kotlin-7F52FF?style=for-the-badge&logo=kotlin&logoColor=white)
+![C++](https://img.shields.io/badge/C%2B%2B-00599C?style=for-the-badge&logo=c%2B%2B&logoColor=white)
+![SQL](https://img.shields.io/badge/SQL-4479A1?style=for-the-badge&logo=postgresql&logoColor=white)
+
+**Infrastructure & Tooling**
+
+![Kubernetes](https://img.shields.io/badge/Kubernetes-326CE5?style=for-the-badge&logo=kubernetes&logoColor=white)
+![Docker](https://img.shields.io/badge/Docker-2496ED?style=for-the-badge&logo=docker&logoColor=white)
+![Jenkins](https://img.shields.io/badge/Jenkins-D24939?style=for-the-badge&logo=jenkins&logoColor=white)
+![Redis](https://img.shields.io/badge/Redis-DC382D?style=for-the-badge&logo=redis&logoColor=white)
+![Prometheus](https://img.shields.io/badge/Prometheus-E6522C?style=for-the-badge&logo=prometheus&logoColor=white)
+![Git](https://img.shields.io/badge/Git-F05032?style=for-the-badge&logo=git&logoColor=white)
+
+---
+
+### GitHub Activity
+
+<div align="center">
+  <img src="https://streak-stats.demolab.com?user=2001adarsh&theme=tokyonight&hide_border=true" alt="GitHub Streak" />
+</div>
+
+---
+
+### Connect
+
+[![LinkedIn](https://img.shields.io/badge/LinkedIn-0A66C2?style=for-the-badge&logo=linkedin&logoColor=white)](https://linkedin.com/in/2001adarsh)
+[![Email](https://img.shields.io/badge/Email-D14836?style=for-the-badge&logo=gmail&logoColor=white)](mailto:2001adarshsingh@gmail.com)
+
 <p align="right">
-<img src="https://komarev.com/ghpvc/?username=2001adarsh" />
+  <img src="https://komarev.com/ghpvc/?username=2001adarsh&color=58A6FF&style=flat" alt="Profile views" />
 </p>

--- a/README.md
+++ b/README.md
@@ -50,6 +50,18 @@ Outside of work I tinker. Recent interests: Go, Kubernetes internals, MCP server
 [![LinkedIn](https://img.shields.io/badge/LinkedIn-0A66C2?style=for-the-badge&logo=linkedin&logoColor=white)](https://linkedin.com/in/2001adarsh)
 [![Email](https://img.shields.io/badge/Email-D14836?style=for-the-badge&logo=gmail&logoColor=white)](mailto:2001adarshsingh@gmail.com)
 
+---
+
+### <img src="https://emojis.slackmojis.com/emojis/images/1569381018/6481/heart-8bit-1.gif?1569381018" width="24" /> Remember
+
+```
+  _ __   _____   _____ _ __    ___  __ _ _   _    _ __   _____   _____ _ __
+ | '_ \ / _ \ \ / / _ \ '__|  / __|/ _` | | | |  | '_ \ / _ \ \ / / _ \ '__|
+ | | | |  __/\ V /  __/ |     \__ \ (_| | |_| |  | | | |  __/\ V /  __/ |
+ |_| |_|\___| \_/ \___|_|     |___/\__,_|\__, |  |_| |_|\___| \_/ \___|_|
+                                         |___/
+```
+
 <p align="right">
   <img src="https://komarev.com/ghpvc/?username=2001adarsh&color=58A6FF&style=flat" alt="Profile views" />
 </p>


### PR DESCRIPTION
## Summary

Updates the profile README to reflect current identity (Backend / Distributed Systems engineer at Pure Storage on PX-Backup, ex-Sophos, ex-F5) rather than the 2020-era Android/Java framing.

- New typing-SVG banner with current role and focus areas
- About section grounds the identity in actual career arc (F5 → Sophos → Pure Storage) and notes the personal repos are interests, not professional work
- Tech stack badges via shields.io: Go-first, plus Java/Kotlin/C++/SQL and the K8s/Docker/Jenkins/Redis/Prometheus stack
- Replaces broken widgets with reliable ones — `github-readme-stats` (503 `DEPLOYMENT_PAUSED`) and `github-profile-trophy` (402 quota exceeded) on Vercel are unreliable, so dropped. Kept `streak-stats.demolab.com`, `readme-typing-svg.demolab.com`, `komarev.com`, and `shields.io` (all 200, stable hosts)
- LinkedIn + email contact badges
- Preserves the "never say never" ASCII quote from the previous README

## Test plan

- [ ] Open the rendered README on GitHub — confirm typing banner, badges, streak card, profile counter, and ASCII quote all render
- [ ] Verify LinkedIn badge links to `linkedin.com/in/2001adarsh`
- [ ] Verify email badge opens `mailto:2001adarshsingh@gmail.com`