### PR TITLE
Fix LinkedIn URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Outside of work I tinker. Recent interests: Go, Kubernetes internals, MCP server
 
 ### Connect
 
-[![LinkedIn](https://img.shields.io/badge/LinkedIn-0A66C2?style=for-the-badge&logo=linkedin&logoColor=white)](https://linkedin.com/in/2001adarsh)
+[![LinkedIn](https://img.shields.io/badge/LinkedIn-0A66C2?style=for-the-badge&logo=linkedin&logoColor=white)](https://www.linkedin.com/in/2001adarshsingh/)
 [![Email](https://img.shields.io/badge/Email-D14836?style=for-the-badge&logo=gmail&logoColor=white)](mailto:2001adarshsingh@gmail.com)
 
 ---


### PR DESCRIPTION
## Summary

The LinkedIn badge in the previous refresh pointed at `linkedin.com/in/2001adarsh`, which doesn't resolve to the right profile. Correct URL is `https://www.linkedin.com/in/2001adarshsingh/`.

## Test plan

- [x] Click the LinkedIn badge from the rendered README — confirm it lands on the correct profile